### PR TITLE
Bind channels where bot reads aloud

### DIFF
--- a/seitai/src/commands/join.rs
+++ b/seitai/src/commands/join.rs
@@ -1,6 +1,8 @@
 use anyhow::{Context as _, Result};
+use hashbrown::HashMap;
 use ordered_float::NotNan;
 use serenity::{
+    all::{ChannelId, GuildId},
     builder::{CreateCommand, CreateEmbed, CreateInteractionResponseMessage},
     client::Context,
     model::{application::CommandInteraction, Colour},
@@ -13,7 +15,12 @@ use crate::{
     utils::{get_guild, get_manager, respond},
 };
 
-pub(crate) async fn run<Repository>(context: &Context, audio_repository: &Repository, interaction: &CommandInteraction) -> Result<()>
+pub(crate) async fn run<Repository>(
+    context: &Context,
+    audio_repository: &Repository,
+    connections: &mut HashMap<GuildId, ChannelId>,
+    interaction: &CommandInteraction,
+) -> Result<()>
 where
     Repository: AudioRepository<Input = Input> + Send + Sync,
 {
@@ -55,6 +62,8 @@ where
         call.join(connect_to).await?
     };
     join.await?;
+
+    connections.insert(guild.id, interaction.channel_id);
 
     let message = CreateInteractionResponseMessage::new().embed(
         CreateEmbed::new()

--- a/seitai/src/main.rs
+++ b/seitai/src/main.rs
@@ -1,6 +1,7 @@
 use std::{env, process::exit, sync::Arc, time::Duration};
 
 use anyhow::{Context as _, Error, Result};
+use hashbrown::HashMap;
 use logging::initialize_logging;
 use serenity::{client::Client, futures::lock::Mutex, model::gateway::GatewayIntents, prelude::TypeMapKey};
 use songbird::SerenityInit;
@@ -78,6 +79,7 @@ async fn main() {
             database: pool,
             speaker,
             audio_repository,
+            connections: Arc::new(Mutex::new(HashMap::new())),
         })
         .register_songbird()
         .await


### PR DESCRIPTION
This fixes #66.
This change restricts channels where the bot reads aloud to the following:

- The text channel where `/join` has been sent
- The text chat in the voice channel where the bot is connected